### PR TITLE
Fixed Tumblr block tag markup

### DIFF
--- a/src/includes/sidebar_widgets.html
+++ b/src/includes/sidebar_widgets.html
@@ -77,6 +77,6 @@
         {block:IfSidebarCustomText}
         <div class="sidebar-widget">
           <span class="widget-title">{text:Sidebar Custom Text Title}</span>
-          {block:IfSidebarCustomText}<p>{text:Sidebar Custom Text}</p>{/block:IfSidebarCustomText}
+          <p>{text:Sidebar Custom Text Content}</p>
         </div>
         {/block:IfSidebarCustomText}

--- a/src/theme.html
+++ b/src/theme.html
@@ -61,8 +61,11 @@
     <meta name="text:Footer Text" content=""/>
     <meta name="text:Google Analytics ID" content=''/>
     <meta name="text:Tagline" content=""/>
-    <meta name="text:Sidebar Custom Text" content=""/>
+
+    <meta name="if:Sidebar Custom Text" content=""/>
+    <meta name="text:Sidebar Custom Text Content" content=""/>
     <meta name="text:Sidebar Custom Text Title" content=""/>
+
     <meta name="text:Username on Facebook" content=''/>
     <meta name="text:Username on Flickr" content=''/>
     <meta name="text:Username on GitHub" content=''/>


### PR DESCRIPTION
Added sidebar custom text boolean meta tag in theme.html to fix error
where Tumblr breaks layout if Custom Text is not specified.